### PR TITLE
Add client-redis dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,19 @@ __Добавление пакета через composer__
 
 `composer require umbrellio/laravel-heavy-jobs`
 
-__Миграция настроек пакета.__
+__Миграция настроек пакета__
 
 `php artisan vendor:publish --tag heavy-jobs-config`
+
+__Проверка зависимостей__
+
+Пакет работает только с редис-клиентом `php-redis`, соответственно нужно проверить что в `config/database.php` 
+значится что-то вроде
+
+```
+'redis' => [
+    'client' => env('REDIS_CLIENT', 'phpredis'),
+```
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "ext-php-redis": "*",
+        "ext-redis": "*",
         "laravel/framework": "^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
+        "ext-php-redis": "*",
         "laravel/framework": "^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Add explicit dependency from `redis` client extension, since this package does not work with `predis` due to differences in the method `eval` signature